### PR TITLE
Added Email confirmation support with Nodemailer

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "express": "^4.17.1",
     "jsonwebtoken": "^8.5.1",
     "mongoose": "^5.11.19",
-    "morgan": "^1.10.0"
+    "morgan": "^1.10.0",
+    "nodemailer": "^6.5.0"
   },
   "devDependencies": {
     "nodemon": "^2.0.7"

--- a/src/controllers/client.controller.js
+++ b/src/controllers/client.controller.js
@@ -44,6 +44,8 @@ module.exports = {
         user,
       } = req;
 
+      delete body.emailIsConfirmed;
+
       const clientUpdate = await Client.findByIdAndUpdate(user, body, {
         new: true,
       }).select('-password');

--- a/src/controllers/user.controller.js
+++ b/src/controllers/user.controller.js
@@ -105,7 +105,7 @@ module.exports = {
       const emailStatus = mailer(email, 'Confirma tu Correo', emailText);
       if(emailStatus !== 'Success!') throw new Error(emailStatus);
 
-      res.status(200).json({ emailToken, fullUser });
+      res.status(200).json({ emailToken });
     } catch(err) {
       res.status(406).json({ message: err.message });
     };

--- a/src/models/client.model.js
+++ b/src/models/client.model.js
@@ -39,6 +39,14 @@ const clientSchema = new Schema({
   photo: {
     type: String,
   },
+  emailIsConfirmed: {
+    type: Boolean,
+    default: false,
+  },
+  emailToken: {
+    type: Number,
+    default: Math.random(),
+  }
 },
 {
   timestamps: true,

--- a/src/models/supplier.model.js
+++ b/src/models/supplier.model.js
@@ -39,6 +39,14 @@ const emailRegex = /(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}
   photo: {
     type: String,
   },
+  emailIsConfirmed: {
+    type: Boolean,
+    default: false,
+  },
+  emailToken: {
+    type: Number,
+    default: Math.random(),
+  }
 },
 {
   timestamps: true,

--- a/src/models/tow.model.js
+++ b/src/models/tow.model.js
@@ -21,7 +21,10 @@ const towSchema = new Schema({
       }
     ] 
   },
-  status: Boolean,
+  status: {
+    type: Boolean,
+    default: false,
+  },
   brand: {
     type: String,
     require: true,

--- a/src/routes/user.js
+++ b/src/routes/user.js
@@ -1,8 +1,11 @@
 const router = require('express').Router();
-const { signin, getLoggedUserInfo } = require('../controllers/user.controller')
-const { auth } = require('../utils/auth')
+const { signin, getLoggedUserInfo, sendConfirmationEmail, confirmEmail } = require('../controllers/user.controller');
+const { auth } = require('../utils/auth');
 
 router.route('/signin').post(signin);
-router.route('/').get(auth, getLoggedUserInfo)
+router.route('/').get(auth, getLoggedUserInfo);
+router.route('/').put(auth, sendConfirmationEmail);
+router.route('/confirm').put(auth, confirmEmail);
+
 
 module.exports = router;

--- a/src/utils/mailer.js
+++ b/src/utils/mailer.js
@@ -1,0 +1,29 @@
+const nodemailer = require('nodemailer');
+
+module.exports = {
+
+  mailer(emailAddress, subject, emailText) {
+    const transporter = nodemailer.createTransport({
+      service: 'gmail',
+      auth: {
+        user: process.env.EMAIL,
+        pass: process.env.PASSWORD,
+      }
+    });
+    
+    const mailOptions = {
+      from: process.env.EMAIL,
+      to: emailAddress,
+      subject: subject,
+      text: emailText,
+    };
+  
+    let status = "Success!";
+  
+    transporter.sendMail(mailOptions, (err) => {
+      if(err) status = `Something went wrong: ${err}`
+    });
+  
+    return status;
+  },
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1198,6 +1198,11 @@ node-fetch@^2.6.1:
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
 
+nodemailer@^6.5.0:
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/nodemailer/-/nodemailer-6.5.0.tgz#d12c28d8d48778918e25f1999d97910231b175d9"
+  integrity sha512-Tm4RPrrIZbnqDKAvX+/4M+zovEReiKlEXWDzG4iwtpL9X34MJY+D5LnQPH/+eghe8DLlAVshHAJZAZWBGhkguw==
+
 nodemon@^2.0.7:
   version "2.0.7"
   resolved "https://registry.yarnpkg.com/nodemon/-/nodemon-2.0.7.tgz#6f030a0a0ebe3ea1ba2a38f71bf9bab4841ced32"


### PR DESCRIPTION
-The Client and Supplier modles now have two additional properties: emailIsConfirmed and emailToken.
-Two new controllers were added for generic users: sendConfirmationEmail and confirmEmail. These send a randomly generated emailToken to a registered user and then receive the token to change the emailIsConfirmed property to true, respectively